### PR TITLE
DS-4362: Fix for sites without sub-domain

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendFeedbackAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendFeedbackAction.java
@@ -64,7 +64,8 @@ public class SendFeedbackAction extends AbstractAction
             // cut off all but the hostname, to cover cases where more than one URL
             // arrives at the installation; e.g. presence or absence of "www"
             int lastDot = host.lastIndexOf('.');
-            basicHost = host.substring(host.substring(0, lastDot).lastIndexOf('.'));
+            if (host.substring(0, lastDot).contains("."))
+                basicHost = host.substring(host.substring(0, lastDot).lastIndexOf('.'));
         }
 
         if ((fromPage == null) || ((!fromPage.contains(basicHost)) && (!isValidReferral(fromPage))))


### PR DESCRIPTION
Fixes breaking of feedback link on sites without sub-domain, i.e., having single dot